### PR TITLE
Add simple Node backend for chat prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# chat-interface
+# Flash AI Consultant Prototype
+
+This repository contains a simple chat interface powered by the OpenAI API. It serves as a starting point for the "Flash AI Consultant" vision, providing a lightweight way to interact with an AI assistant that can deliver strategic insights.
+
+## Setup
+
+1. Install Node dependencies:
+
+```bash
+npm install
+```
+
+2. Create a `.env` file in the project root and set your OpenAI API key:
+
+```
+OPENAI_API_KEY=your-api-key
+```
+
+3. Run the development server:
+
+```bash
+npm start
+```
+
+4. Open `http://localhost:3000` in your browser to chat with the assistant.
+
+This is an early prototype and does not yet include retrieval or advanced features from the vision statement, but it lays the groundwork for future development.

--- a/index.html
+++ b/index.html
@@ -3,16 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Chat Interface</title>
+  <title>Flash AI Consultant</title>
   <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
 </head>
 <body>
   <div class="chat-container">
-    <ul class="chat-list">
-      <li class="chat-message sent">Hello! How are you?</li>
-      <li class="chat-message received">I'm good, thanks! How about you?</li>
-      <li class="chat-message sent">Doing well, thanks for asking!</li>
-    </ul>
+    <ul class="chat-list" id="chat-list"></ul>
+    <form id="chat-form" class="chat-form">
+      <input id="message-input" type="text" placeholder="Type a message..." autocomplete="off" />
+      <button type="submit">Send</button>
+    </form>
   </div>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "flash-ai-consultant",
+  "version": "1.0.0",
+  "description": "Prototype for Flash AI Consultant chat interface.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "openai": "^4.17.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const chatList = document.getElementById('chat-list');
+  const form = document.getElementById('chat-form');
+  const input = document.getElementById('message-input');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const message = input.value.trim();
+    if (!message) return;
+    addMessage(message, 'sent');
+    input.value = '';
+
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message })
+      });
+      if (response.ok) {
+        const data = await response.json();
+        addMessage(data.reply, 'received');
+      } else {
+        const err = await response.json();
+        addMessage('Error: ' + err.error, 'received');
+      }
+    } catch (err) {
+      addMessage('Network error', 'received');
+    }
+  });
+
+  function addMessage(text, type) {
+    const li = document.createElement('li');
+    li.className = `chat-message ${type}`;
+    li.textContent = text;
+    chatList.appendChild(li);
+    chatList.scrollTop = chatList.scrollHeight;
+  }
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const path = require('path');
+const { Configuration, OpenAIApi } = require('openai');
+require('dotenv').config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname)));
+app.use(express.json());
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const openai = new OpenAIApi(configuration);
+
+app.post('/api/chat', async (req, res) => {
+  const { message } = req.body;
+  if (!message) return res.status(400).json({ error: 'Message is required' });
+
+  try {
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: message }],
+    });
+    const reply = completion.data.choices[0].message.content.trim();
+    res.json({ reply });
+  } catch (err) {
+    console.error('OpenAI API error:', err.message);
+    res.status(500).json({ error: 'AI service error' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -7,24 +7,29 @@ body {
 
 .chat-container {
   width: 400px;
+  height: 600px;
   margin: 50px auto;
   background-color: #fff;
   border-radius: 5px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
 .chat-list {
   list-style: none;
-  padding: 0;
+  padding: 10px;
   margin: 0;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .chat-message {
   padding: 10px 15px;
-  margin: 5px;
+  margin: 5px 0;
   border-radius: 20px;
-  display: inline-block;
+  max-width: 80%;
 }
 
 .sent {
@@ -37,4 +42,23 @@ body {
   background-color: #e9ecef;
   color: #333;
   align-self: flex-start;
+}
+
+.chat-form {
+  display: flex;
+  border-top: 1px solid #ddd;
+}
+
+.chat-form input {
+  flex: 1;
+  padding: 10px;
+  border: none;
+}
+
+.chat-form button {
+  padding: 10px 15px;
+  border: none;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- implement prototype chat server using Express and OpenAI API
- add minimal frontend JavaScript for sending messages
- update HTML and CSS to support interactive chat
- document setup steps in README
- add Node project files and gitignore

## Testing
- `npm install` *(fails: network unreachable)*